### PR TITLE
Align skills & experience glass aesthetic

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import path from 'path';
 
 import Hero from '@/components/Hero';
 import Projects, { type Project } from '@/components/Projects';
+import Skills, { type SkillsContent } from '@/components/Skills';
 import WorkExperience, { type WorkExperienceContent } from '@/components/WorkExperience';
 
 interface TechFocus {
@@ -23,13 +24,14 @@ interface ProfessionalPageContent {
   hero: HeroContent;
   projects?: Project[];
   workExperience?: WorkExperienceContent;
+  skills?: SkillsContent;
 }
 
 export default async function Home() {
   const filePath = path.join(process.cwd(), 'data', 'professional-page.json');
   const fileContents = await fs.readFile(filePath, 'utf8');
   const content = JSON.parse(fileContents) as ProfessionalPageContent;
-  const { hero, projects = [], workExperience } = content;
+  const { hero, projects = [], workExperience, skills } = content;
 
   return (
     <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-12 px-6 pb-16 pt-32 sm:pt-36 md:gap-16 md:px-10 md:pt-40 lg:px-12">
@@ -42,6 +44,7 @@ export default async function Home() {
       />
       <Projects projects={projects} />
       {workExperience ? <WorkExperience {...workExperience} /> : null}
+      {skills ? <Skills {...skills} /> : null}
     </main>
   );
 }

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { List, Sparkles, icons, type LucideIcon } from "lucide-react";
+
+interface SkillCategory {
+  id: string;
+  title: string;
+  icon?: string;
+  summary?: string;
+  highlights?: string[];
+  familiar?: string[];
+  tags?: string[];
+}
+
+interface Certification {
+  id: string;
+  label: string;
+  issuer?: string;
+  year?: string;
+  icon?: string;
+  link?: string;
+}
+
+interface ViewModes {
+  primaryLabel: string;
+  allLabel: string;
+}
+
+export interface SkillsContent {
+  heading: string;
+  subheading?: string;
+  viewModes: ViewModes;
+  categories: SkillCategory[];
+  certifications?: Certification[];
+}
+
+const fallbackIcon = icons.Circle as LucideIcon;
+
+const getIconComponent = (iconName?: string): LucideIcon => {
+  if (!iconName) {
+    return fallbackIcon;
+  }
+
+  const normalized = iconName as keyof typeof icons;
+  return icons[normalized] ?? fallbackIcon;
+};
+
+const CategoryIcon = ({ icon, className }: { icon?: string; className?: string }) => {
+  const Icon = useMemo(() => getIconComponent(icon), [icon]);
+  return <Icon aria-hidden="true" className={className} />;
+};
+
+const CertificationIcon = ({ icon, className }: { icon?: string; className?: string }) => {
+  const Icon = useMemo(() => getIconComponent(icon), [icon]);
+  return <Icon aria-hidden="true" className={className} />;
+};
+
+const chipBaseClasses =
+  "inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide";
+
+const Skills: React.FC<SkillsContent> = ({
+  heading,
+  subheading,
+  viewModes,
+  categories,
+  certifications = [],
+}) => {
+  const [showAll, setShowAll] = useState(false);
+
+  const visibleCategories = useMemo(() => categories, [categories]);
+
+  if (!visibleCategories.length) {
+    return null;
+  }
+
+  const primaryLabel = viewModes.primaryLabel ?? "Core";
+  const allLabel = viewModes.allLabel ?? "All";
+
+  return (
+    <section id="skills" className="scroll-mt-32">
+      <div className="text-center">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-slate-500 sm:text-xs">
+          {heading}
+        </p>
+        {subheading ? (
+          <h2 className="mx-auto mt-4 max-w-2xl text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+            {subheading}
+          </h2>
+        ) : null}
+      </div>
+
+      <div className="mt-8 flex w-full justify-center">
+        <div className="inline-flex items-center gap-3 rounded-full border border-slate-200/60 bg-white/70 px-3 py-2 shadow-sm backdrop-blur">
+          <span className="hidden text-xs font-medium text-slate-500 sm:inline">View</span>
+          <div className="inline-flex rounded-full bg-slate-100 p-1">
+            <button
+              type="button"
+              onClick={() => setShowAll(false)}
+              aria-pressed={!showAll}
+              className={`flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 sm:px-3.5 sm:py-2 sm:text-sm ${
+                showAll ? "text-slate-500 hover:text-slate-700" : "bg-white text-slate-900 shadow"
+              }`}
+            >
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+              <span>{primaryLabel}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              aria-pressed={showAll}
+              className={`flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300 sm:px-3.5 sm:py-2 sm:text-sm ${
+                showAll ? "bg-white text-slate-900 shadow" : "text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              <List className="h-4 w-4" aria-hidden="true" />
+              <span>{allLabel}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {visibleCategories.map((category) => (
+          <article
+            key={category.id}
+            className="glass-pane group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/20 p-6 transition-transform duration-300 hover:-translate-y-1"
+          >
+            <div className="relative z-[1] flex h-full flex-col gap-5">
+                <header className="flex items-start gap-3">
+                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-white/30 bg-white/60 text-slate-500 shadow-inner backdrop-blur">
+                    <CategoryIcon icon={category.icon} className="h-5 w-5" />
+                    <span className="sr-only">{category.title}</span>
+                  </span>
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">{category.title}</h3>
+                    {category.summary ? (
+                      <p className="mt-1 text-sm text-slate-600">{category.summary}</p>
+                    ) : null}
+                  </div>
+                </header>
+
+                {category.highlights?.length ? (
+                  <div className="flex flex-wrap gap-2">
+                    {category.highlights.map((skill) => (
+                      <span
+                        key={`${category.id}-highlight-${skill}`}
+                        className={`${chipBaseClasses} border-white/30 bg-white/45 text-slate-600 backdrop-blur`}
+                      >
+                        {skill}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+
+                {showAll && category.familiar?.length ? (
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    {category.familiar.map((skill) => (
+                      <span
+                        key={`${category.id}-fam-${skill}`}
+                        className={`${chipBaseClasses} border-white/20 bg-white/35 text-slate-500 backdrop-blur`}
+                      >
+                        {skill}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {certifications.length ? (
+        <div className="mt-10 rounded-2xl border border-slate-200/60 bg-white/70 p-5 shadow-sm backdrop-blur">
+          <div className="flex flex-wrap items-center gap-3">
+            {certifications.map((cert) => {
+              const content = (
+                <span
+                  key={cert.id}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/75 px-3 py-1.5 text-xs font-semibold text-slate-700"
+                >
+                  <CertificationIcon icon={cert.icon ?? "ShieldCheck"} className="h-4 w-4" />
+                  <span>{cert.label}</span>
+                  {cert.year ? (
+                    <span className="text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
+                      {cert.year}
+                    </span>
+                  ) : null}
+                </span>
+              );
+
+              if (cert.link) {
+                return (
+                  <a
+                    key={cert.id}
+                    href={cert.link}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="transition hover:-translate-y-0.5 hover:shadow"
+                  >
+                    {content}
+                  </a>
+                );
+              }
+
+              return content;
+            })}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+};
+
+export default Skills;

--- a/components/WorkExperience.tsx
+++ b/components/WorkExperience.tsx
@@ -33,32 +33,32 @@ type ExperienceView = "timeline" | "cards";
 
 const accentStyles: Record<WorkExperienceAccent, { dot: string; innerDot: string; ring: string; badge: string; chip: string }> = {
   blue: {
-    dot: "border-sky-300",
-    innerDot: "bg-sky-500",
-    ring: "ring-2 ring-sky-200/65",
-    badge: "bg-sky-100 text-sky-700",
-    chip: "border border-sky-100 bg-sky-50 text-sky-700",
+    dot: "border-sky-300/70",
+    innerDot: "bg-sky-400",
+    ring: "ring-2 ring-sky-200/60",
+    badge: "border border-white/30 bg-white/45 text-sky-700 backdrop-blur",
+    chip: "border border-white/25 bg-white/35 text-slate-600 backdrop-blur",
   },
   slate: {
-    dot: "border-sky-300",
-    innerDot: "bg-sky-500",
-    ring: "ring-2 ring-sky-200/65",
-    badge: "bg-sky-100 text-sky-700",
-    chip: "border border-sky-100 bg-sky-50 text-sky-700",
+    dot: "border-slate-300/70",
+    innerDot: "bg-slate-400",
+    ring: "ring-2 ring-slate-200/60",
+    badge: "border border-white/30 bg-white/45 text-slate-700 backdrop-blur",
+    chip: "border border-white/25 bg-white/35 text-slate-600 backdrop-blur",
   },
   violet: {
-    dot: "border-sky-300",
-    innerDot: "bg-sky-500",
-    ring: "ring-2 ring-sky-200/65",
-    badge: "bg-sky-100 text-sky-700",
-    chip: "border border-sky-100 bg-sky-50 text-sky-700",
+    dot: "border-violet-300/70",
+    innerDot: "bg-violet-400",
+    ring: "ring-2 ring-violet-200/60",
+    badge: "border border-white/30 bg-white/45 text-violet-700 backdrop-blur",
+    chip: "border border-white/25 bg-white/35 text-slate-600 backdrop-blur",
   },
   teal: {
-    dot: "border-sky-300",
-    innerDot: "bg-sky-500",
-    ring: "ring-2 ring-sky-200/65",
-    badge: "bg-sky-100 text-sky-700",
-    chip: "border border-sky-100 bg-sky-50 text-sky-700",
+    dot: "border-teal-300/70",
+    innerDot: "bg-teal-400",
+    ring: "ring-2 ring-teal-200/60",
+    badge: "border border-white/30 bg-white/45 text-teal-700 backdrop-blur",
+    chip: "border border-white/25 bg-white/35 text-slate-600 backdrop-blur",
   },
 };
 
@@ -121,9 +121,9 @@ const WorkExperience: React.FC<WorkExperienceContent> = ({
       </div>
 
       <div className="mt-8 flex w-full justify-center">
-        <div className="inline-flex items-center gap-3 rounded-full border border-slate-200/60 bg-white/70 px-3 py-2 shadow-sm backdrop-blur">
-          <span className="hidden text-xs font-medium text-slate-500 sm:inline">{viewPrompt}</span>
-          <div className="inline-flex rounded-full bg-slate-100 p-1">
+        <div className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/45 px-3 py-2 shadow-sm backdrop-blur">
+          <span className="hidden text-xs font-medium text-slate-600 sm:inline">{viewPrompt}</span>
+          <div className="inline-flex rounded-full bg-white/40 p-1 backdrop-blur">
             <ToggleButton
               icon={CalendarClock}
               label={timelineLabel}
@@ -204,8 +204,9 @@ const TimelineItem: React.FC<TimelineItemProps> = ({ entry, open, onToggle }) =>
       >
         <span className={`h-2 w-2 rounded-full ${accent.innerDot}`} aria-hidden="true" />
       </span>
-      <article className={`glass-pane relative overflow-hidden rounded-2xl border border-slate-200/60 p-6 ring-0 transition-shadow duration-300 ${open ? accent.ring : ""}`}>
-        <div className="pointer-events-none absolute inset-0 bg-sky-100/20" aria-hidden="true" />
+      <article
+        className={`glass-pane group relative flex flex-col overflow-hidden rounded-2xl border border-white/20 p-6 transition-transform duration-300 ${open ? accent.ring : "ring-0"} hover:-translate-y-1`}
+      >
         <div className="relative z-[1] flex flex-col gap-6">
           <header className="flex flex-col gap-3 sm:grid sm:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] sm:items-start sm:gap-6">
             <div>
@@ -279,11 +280,10 @@ const CardItem: React.FC<CardItemProps> = ({ entry, open, onToggle }) => {
 
   return (
     <article
-      className={`glass-pane relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/60 p-6 transition-shadow duration-300 ${
-        open ? accent.ring : ""
+      className={`glass-pane group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/20 p-6 transition-transform duration-300 hover:-translate-y-1 ${
+        open ? accent.ring : "ring-0"
       }`}
     >
-      <div className="pointer-events-none absolute inset-0 bg-sky-100/20" aria-hidden="true" />
       <div className="relative z-[1] flex h-full flex-col">
         <header className="flex flex-col gap-3">
           <div className="flex items-start justify-between gap-4">

--- a/data/professional-page.json
+++ b/data/professional-page.json
@@ -176,6 +176,93 @@
       }
     ]
   },
+  "skills": {
+    "heading": "Skills & Certifications",
+    "subheading": "A toolkit tuned for reliable, human-centered delivery.",
+    "viewModes": {
+      "primaryLabel": "Core strengths",
+      "allLabel": "Full toolkit"
+    },
+    "categories": [
+      {
+        "id": "languages",
+        "title": "Languages",
+        "icon": "Languages",
+        "summary": "Languages I lean on for systems work and storytelling with data.",
+        "highlights": ["Python", "TypeScript", "SQL"],
+        "familiar": ["C#", "Java", "C++"],
+        "tags": ["languages"]
+      },
+      {
+        "id": "backend",
+        "title": "Backend & Infrastructure",
+        "icon": "Server",
+        "summary": "Services, orchestration, and delivery patterns built for uptime.",
+        "highlights": ["FastAPI", "Node.js", "PostgreSQL", "Docker"],
+        "familiar": ["Redis", "pgvector", "Terraform", "GitHub Actions"],
+        "tags": ["backend", "data"]
+      },
+      {
+        "id": "cloud",
+        "title": "Cloud Platform",
+        "icon": "Cloud",
+        "summary": "Cloud components used to stitch together secure, scalable systems.",
+        "highlights": ["GCP", "Cloud Run", "Pub/Sub"],
+        "familiar": ["BigQuery", "Firestore", "Azure Functions", "Azure Cognitive Search"],
+        "tags": ["cloud", "data"]
+      },
+      {
+        "id": "ai",
+        "title": "AI & Information Retrieval",
+        "icon": "Bot",
+        "summary": "Applied ML capabilities for semantic search and grounded assistants.",
+        "highlights": ["Vector Search", "RAG Pipelines", "Prompt Engineering"],
+        "familiar": ["LangChain", "Autogen", "Azure OpenAI"],
+        "tags": ["ai", "data"]
+      },
+      {
+        "id": "frontend",
+        "title": "Frontend & Product UI",
+        "icon": "MonitorSmartphone",
+        "summary": "Interfaces that balance clarity with motion and accessibility.",
+        "highlights": ["React", "Next.js", "Tailwind CSS"],
+        "familiar": ["Design Systems", "Framer Motion", "Flutter"],
+        "tags": ["frontend"]
+      },
+      {
+        "id": "data",
+        "title": "Data & Analytics",
+        "icon": "ChartPie",
+        "summary": "Pipelines and tooling that surface trustworthy insight.",
+        "highlights": ["Databricks", "dbt", "Looker"],
+        "familiar": ["Power BI", "Tableau", "Great Expectations"],
+        "tags": ["data"]
+      }
+    ],
+    "certifications": [
+      {
+        "id": "databricks-de-associate",
+        "label": "Databricks Certified Data Engineer Associate",
+        "issuer": "Databricks",
+        "year": "2024",
+        "icon": "ShieldCheck"
+      },
+      {
+        "id": "databricks-da-associate",
+        "label": "Databricks Certified Data Analyst Associate",
+        "issuer": "Databricks",
+        "year": "2024",
+        "icon": "ShieldCheck"
+      },
+      {
+        "id": "scrum-at-scale",
+        "label": "Scrum@Scale Practitioner",
+        "issuer": "Scrum Inc.",
+        "year": "2023",
+        "icon": "Sparkles"
+      }
+    ]
+  },
   "careerPath": [
     {
       "id": 1,


### PR DESCRIPTION
## Summary
- wire skills section onto the homepage and seed content
- switch skills cards to match the projects glass-pane styling
- bring work experience timeline/cards into the same translucent theme

## Testing
- npm run lint